### PR TITLE
generate upload token with user’s `options`

### DIFF
--- a/lib/up.js
+++ b/lib/up.js
@@ -60,7 +60,7 @@ exports.uploadToken = function uploadToken(options) {
 /**
  * Upload file content
  * 
- * @param {String|Buffer|Stream} file content string or buffer, or a Stream instance.
+ * @param {String|Buffer|Stream} content file content string or buffer, or a Stream instance.
  * @param {Object} [options]
  *  - {String} [key] 标识文件的索引，所在的存储空间内唯一。key可包含斜杠，但不以斜杠开头，比如 a/b/c.jpg 是一个合法的key。
  *                   若不指定 key，缺省使用文件的 etag（即上传成功后返回的hash值）作为key；
@@ -120,7 +120,7 @@ exports.upload = function upload(content, options, callback) {
   }
 
   var that = this;
-  form.field('token', that.uploadToken());
+  form.field('token', that.uploadToken(options));
 
   if (options.key) {
     form.field('key', this.resourceKey(String(options.key)));


### PR DESCRIPTION
用户可以通过传参，改变生成 token 的策略，从而完成上传直接覆盖文件的操作。

Users can pass parameters to change the policy token is generated, thereby uploading and directly overwriting a file.